### PR TITLE
Feat/add keyboard margin to edit view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Added
 
+- EditView에서 키보드에 따라 bottom constraint 조정
+
 ### Changed
 
 ### Deprecated

--- a/kkumku/Views/Base.lproj/Main.storyboard
+++ b/kkumku/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="APQ-eA-oUN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="APQ-eA-oUN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -178,6 +178,7 @@
                     <navigationItem key="navigationItem" id="h9R-kT-vfj"/>
                     <connections>
                         <outlet property="tableView" destination="BZ4-hV-faT" id="eaZ-z5-3mr"/>
+                        <outlet property="tableViewBottomConstraint" destination="lAt-UU-4D9" id="xCz-o7-R5r"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IMt-cw-8wg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/kkumku/Views/Edit/EditViewController.swift
+++ b/kkumku/Views/Edit/EditViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class EditViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var tableViewBottomConstraint: NSLayoutConstraint!
     
     var isInsertingNewDream = true
     var workingDream = Dream(startAt: Date.now, endAt: Date.now, memo: "", dreamClass: .auspicious, isLucid: false)
@@ -43,6 +44,8 @@ class EditViewController: UIViewController {
         tableView.rowHeight = UITableView.automaticDimension
         
         NotificationCenter.default.addObserver(self, selector: #selector(appBecameActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(willKeyboardShow(_:)), name: UIView.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(willKeyboardHide(_:)), name: UIView.keyboardWillHideNotification, object: nil)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -64,5 +67,22 @@ class EditViewController: UIViewController {
             workingDream.endAt = Date.now
             tableView.reloadData()
         }
+    }
+    
+    @objc private func willKeyboardShow(_ notification: Notification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardHeight: CGFloat = keyboardFrame.cgRectValue.height - view.safeAreaInsets.bottom
+            adjustBottomConstraint(with: keyboardHeight)
+            Log.debug("EditViewController willKeyboardShow - keyboardHeight=\(keyboardHeight)")
+        }
+    }
+    
+    @objc private func willKeyboardHide(_ notification: Notification) {
+        adjustBottomConstraint(with: 0)
+        Log.debug("EditViewController willKeyboardHide")
+    }
+    
+    private func adjustBottomConstraint(with constant: CGFloat) {
+        tableViewBottomConstraint.constant = constant
     }
 }


### PR DESCRIPTION
- 관련 이슈: https://github.com/0tak2/kkumku/issues/62
- 참고 자료: https://stackoverflow.com/questions/31774006/how-to-get-height-of-keyboard
- 변경점
  -  NotificationCenter에 키보드 관련 처리를 할 옵저버 등록
  - 키보드 등장 시 뷰와 테이블 뷰의 bottom constraint의 constant를 키보드 높이만큼 더함
  - 이때 세이프 영역의 높이를 뺴줘야 원하는 키보드만의 높이가 나옴에 주의 (`keyboardFrame.cgRectValue.height - view.safeAreaInsets.bottom`)
  - iOS 9부터 옵저버는 알아서 해제되므로 deinit에서 제거할 필요 없다는 것을 확인 (참고 자료: [https://stackoverflow.com/questions/28689989/where-to-remove-observer-for-nsnotification-in-swift](https://stackoverflow.com/questions/28689989/where-to-remove-observer-for-nsnotification-in-swift))